### PR TITLE
fix(pubsub): Added sender id storing in pubsub.

### DIFF
--- a/app/js/adapter/owf7Bridge/modules/eventing.js
+++ b/app/js/adapter/owf7Bridge/modules/eventing.js
@@ -31,7 +31,7 @@ ozpIwc.owf7BridgeModules.eventing = function(listener){
              * @see js-lib/shindig/pubsub_router.js
              */
             'pubsub': function (command, channel, message, dest) {
-                listener.getParticipant(this.f).eventing.onPubsub(command,channel,message,dest);
+                listener.getParticipant(this.f).eventing.onPubsub(command,channel,message,dest,this.f);
             }
         }
     };

--- a/app/js/adapter/owf7Participant/modules/eventing.js
+++ b/app/js/adapter/owf7Participant/modules/eventing.js
@@ -55,10 +55,10 @@ ozpIwc.owf7ParticipantModules.Eventing.prototype.onContainerInit=function(sender
  * @param {String} message
  * @param {String} dest
  */
-ozpIwc.owf7ParticipantModules.Eventing.prototype.onPubsub = function(command,channel,message,dest){
+ozpIwc.owf7ParticipantModules.Eventing.prototype.onPubsub = function(command,channel,message,dest,sender){
     switch (command) {
         case 'publish':
-            this.onPublish(command, channel, message, dest);
+            this.onPublish(command, channel, message, dest, sender);
             break;
         case 'subscribe':
             this.onSubscribe(command, channel, message, dest);
@@ -77,7 +77,7 @@ ozpIwc.owf7ParticipantModules.Eventing.prototype.onPubsub = function(command,cha
  * @param {String} message
  * @param {String} dest
  */
-ozpIwc.owf7ParticipantModules.Eventing.prototype.onPublish=function(command, channel, message, dest) {
+ozpIwc.owf7ParticipantModules.Eventing.prototype.onPublish=function(command, channel, message, dest, sender) {
     if(this.participant.dd["hookPublish"+channel] && !this.participant.dd["hookPublish"+channel].call(this.participant.dd,message)) {
         return;
     }
@@ -85,7 +85,10 @@ ozpIwc.owf7ParticipantModules.Eventing.prototype.onPublish=function(command, cha
         "dst": "data.api",
         "resource": ozpIwc.owf7ParticipantModules.Eventing.pubsubChannel(channel),
         "action": "set",
-        "entity": message
+        "entity": {
+            "message": message,
+            "sender": sender
+        }
     });
 };
 
@@ -116,7 +119,7 @@ ozpIwc.owf7ParticipantModules.Eventing.prototype.onSubscribe=function(command, c
         if(self.subscriptions[channel]) {
             // from shindig/pubsub_router.js:77
             //gadgets.rpc.call(subscriber, 'pubsub', null, channel, sender, message);
-            gadgets.rpc.call(self.participant.rpcId, 'pubsub', null, channel, null, packet.entity.newValue);
+            gadgets.rpc.call(self.participant.rpcId, 'pubsub', null, channel, packet.entity.newValue.sender, packet.entity.newValue.message);
         }else {
             done();
         }


### PR DESCRIPTION
refs #17 

When a subscribe handler is called, it receives two parameters `sender` and `event`(message).

these are passed as the entity of the data.api [entity](https://github.com/ozone-development/ozp-iwc-owf7-widget-adapter/compare/feature-pubsubSender?expand=1#diff-c013c1edd551f681e47c0040b8d66860R88)