### PR TITLE
Intents & RPC handling

### DIFF
--- a/app/js/adapter/owf7Bridge/modules/intents.js
+++ b/app/js/adapter/owf7Bridge/modules/intents.js
@@ -21,7 +21,7 @@ ozpIwc.owf7BridgeModules.intents = function(listener){
              * @param destIds
              */
             '_intents': function(senderId, intent, data, destIds){
-                //@TODO
+                listener.getParticipant(this.f).intents.onIntents(senderId,intent,data,destIds);
             },
             /**
              * used by widgets to register an intent
@@ -30,7 +30,7 @@ ozpIwc.owf7BridgeModules.intents = function(listener){
              * @param destWidgetId
              */
             '_intents_receive': function(intent, destWidgetId){
-                //@TODO
+                listener.getParticipant(this.f).intents.onIntentsReceive(intent,destWidgetId);
             }
         }
     };

--- a/app/js/adapter/owf7Participant/modules/dd.js
+++ b/app/js/adapter/owf7Participant/modules/dd.js
@@ -107,8 +107,7 @@ ozpIwc.owf7ParticipantModules.Dd.prototype.onFakeMouseMoveFromOthers=function(ms
         gadgets.rpc.call(this.participant.rpcId, '_fire_mouse_move', null,localizedEvent);
     } else {
         if(this.mouseOver) {
-            console.log("Faking an mouse dragOut at page("
-                +localizedEvent.pageX+","+localizedEvent.pageY+")");
+            //console.log("Faking an mouse dragOut at page(" + localizedEvent.pageX+","+localizedEvent.pageY + ")");
             // this.eventingContainer.publish(this.dragOutName, null, lastEl.id);
             // fake the pubsub event directly to the recipient
             gadgets.rpc.call(this.participant.rpcId, 'pubsub', null, "_dragOutName", "..", null);
@@ -260,7 +259,7 @@ ozpIwc.owf7ParticipantModules.Dd.prototype.hookReceive_dropReceiveData=function(
  * @returns {Boolean}
  */
 ozpIwc.owf7ParticipantModules.Dd.prototype.hookReceive_dragStart=function(message) {
-    console.log("Starting external drag on ",message);
+    //console.log("Starting external drag on ",message);
     this.participant.listener.inDrag=true;
     return true;
 };
@@ -272,7 +271,7 @@ ozpIwc.owf7ParticipantModules.Dd.prototype.hookReceive_dragStart=function(messag
  * @returns {Boolean}
  */
 ozpIwc.owf7ParticipantModules.Dd.prototype.hookPublish_dragStart=function(message) {
-    console.log("Starting internal drag on ",message);
+    //console.log("Starting internal drag on ",message);
     this.participant.listener.inDrag=true;
     return true;
 };
@@ -356,7 +355,7 @@ ozpIwc.owf7ParticipantModules.Dd.prototype.hookPublish_dragStopInWidget=function
     },function(packet,done) {
 
         if(packet.response==="ok") {
-            console.log("Completing drag of data ",packet.entity);
+            //console.log("Completing drag of data ",packet.entity);
             gadgets.rpc.call(self.participant.rpcId, 'pubsub', null, "_dropReceiveData", "..", packet.entity);
         } else {
             //console.log("Unable to fetch drag data",packet);

--- a/app/js/adapter/owf7Participant/modules/intents.js
+++ b/app/js/adapter/owf7Participant/modules/intents.js
@@ -1,0 +1,75 @@
+ozpIwc = ozpIwc || {};
+ozpIwc.owf7ParticipantModules = ozpIwc.owf7ParticipantModules || {};
+
+/**
+ * An Intents module for the owf7Participant.
+ * @namespace ozpIwc.owf7ParticipantModules
+ * @class Intents
+ * @param participant
+ * @constructor
+ */
+ozpIwc.owf7ParticipantModules.Intents = function(participant){
+    if(!participant) { throw "Needs to have an OWF7ParticipantListener";}
+    this.participant = participant;
+};
+
+
+/**
+ * @method onIntents
+ * @param senderId
+ * @param intent
+ * @param data
+ * @param destIds
+ */
+ozpIwc.owf7ParticipantModules.Intents.prototype.onIntents=function(senderId,intent,data,destIds){
+    intent = intent || {};
+    if(!intent.dataType) { throw "A legacy intent registration requires a dataType.";}
+    if(!intent.action) { throw "A legacy intent registration requires an action.";}
+
+    this.participant.client.send({
+        'dst': "intents.api",
+        'action': "invoke",
+        'resource': '/' + intent.dataType + '/' + intent.action,
+        'entity': {
+            entity: data,
+            destIds: destIds,
+            senderId: senderId
+        }
+    },function(resp){
+        //@TODO
+    });
+};
+
+/**
+ * @method onIntentsReceive
+ * @param {Object} intent
+ * @param {String} destWidgetId
+ */
+ozpIwc.owf7ParticipantModules.Intents.prototype.onIntentsReceive=function(intent,destWidgetId) {
+    intent = intent || {};
+    if(!intent.dataType) { throw "A legacy intent registration requires a dataType.";}
+    if(!intent.action) { throw "A legacy intent registration requires an action.";}
+
+    this.participant.client.send({
+        'dst': "intents.api",
+        'action': "register",
+        'resource': '/' + intent.dataType + '/' + intent.action,
+        'entity': {
+            'type': intent.dataType,
+            'action': intent.action,
+            'icon': this.participant.appData.icons.small || "about:blank",
+            'label': this.participant.widgetParams.name
+        }
+    }, function (response) {
+        if (response.entity && response.entity.inFlightIntentEntity && response.entity.inFlightIntentEntity.entity) {
+            var ifie = response.entity.inFlightIntentEntity;
+            var entity = ifie.entity;
+            var intentObj = {
+                'action': ifie.intent.action,
+                'dataType': ifie.intent.type
+            };
+
+            gadgets.rpc.call(destWidgetId, "_intents", null, entity.senderId, intentObj, entity.entity);
+        }
+    });
+};

--- a/app/js/adapter/owf7Participant/owf7Participant.js
+++ b/app/js/adapter/owf7Participant/owf7Participant.js
@@ -29,6 +29,7 @@ ozpIwc.Owf7Participant=function(config) {
     this.instanceId=config.instanceId;
     this.widgetGuid=config.guid;
     this.rpcId=config.rpcId;
+    this.onReady = config.onReady;
 
     // Create an iframe for the widget
     this.iframe = document.createElement('iframe');
@@ -75,6 +76,7 @@ ozpIwc.Owf7Participant.prototype._initModules = function(){
     this.eventing = new ozpIwc.owf7ParticipantModules.Eventing(this);
     this.kernel = new ozpIwc.owf7ParticipantModules.Kernel(this);
     this.components = new ozpIwc.owf7ParticipantModules.Components(this);
+    this.intents = new ozpIwc.owf7ParticipantModules.Intents(this);
 };
 
 /**
@@ -108,7 +110,15 @@ ozpIwc.Owf7Participant.prototype._initIframe=function() {
         "data": this.launchData
 	};
 
-    this.setWidgetTitle();
+    var self =this;
+    this._getApplicationData(function(appData){
+        self.appData = appData || {};
+        self.setWidgetTitle(self.appData.name);
+        if(typeof self.onReady === "function"){
+            self.onReady();
+        }
+    });
+
     this.iframe.setAttribute("name",JSON.stringify(this.widgetParams));
     this.iframe.setAttribute("src",this.widgetParams.url+this.widgetQuery);
     this.iframe.setAttribute("id",this.rpcId);
@@ -136,23 +146,17 @@ ozpIwc.Owf7Participant.prototype._getApplicationData = function(cb){
 };
 
 /**
- * Sets the document title to that of the widget if it is registered to the System.api. If it is not the title is
+ * Sets the document title to the given name. If no name given, the title is
  * set with the following pattern "<href.host><href.pathname> -- OWF Widget".
  * @method setWidgetTitle
  * @param {Function} cb callback which will return the set title.
  */
-ozpIwc.Owf7Participant.prototype.setWidgetTitle = function(cb){
-    cb = cb || function(){};
-    var self = this;
-    this._getApplicationData(function(data){
-        if(data.name){
-            self.widgetParams.name = data.name;
-        } else {
-            var a=document.createElement("a");
-            a.href = self.widgetParams.url;
-            self.widgetParams.name = a.host + a.pathname + " -- OWF Widget";
-        }
-        document.title = self.widgetParams.name;
-        cb(document.title);
-    });
+ozpIwc.Owf7Participant.prototype.setWidgetTitle = function(name){
+    if(!name){
+        var a=document.createElement("a");
+        a.href = this.widgetParams.url;
+        name = a.host + a.pathname + " -- OWF Widget";
+    }
+    document.title = name;
+    return document.title;
 };

--- a/app/js/adapter/owf7ParticipantListener.js
+++ b/app/js/adapter/owf7ParticipantListener.js
@@ -117,6 +117,7 @@
      * @returns {*}
      */
     ozpIwc.Owf7ParticipantListener.prototype.addWidget=function(config) {
+        config = config || {};
         var self = this;
         var participantConfig = {};
 

--- a/app/js/shindig/rpc.js
+++ b/app/js/shindig/rpc.js
@@ -214,8 +214,18 @@ gadgets.rpc = function() {
         if(msg) {
             process(msg);
         }
-      }
+      };
 
+      // the widget's rpc will try and run up the chain to the widget opener if same domain.
+      // we must do the same to capture the message if the opener was non legacy. If cross domain this rpc will catch
+      // the message.
+      if(window.opener){
+        if(window.opener.parent){
+          window.opener.parent.addEventListener('message',onmessage, false);
+        } else {
+          window.opener.addEventListener('message',onmessage, false);
+        }
+      }
       if (typeof window.addEventListener != 'undefined') {
         window.addEventListener('message', onmessage, false);
       } else if (typeof window.attachEvent != 'undefined') {

--- a/app/owf7adapter.html
+++ b/app/owf7adapter.html
@@ -34,7 +34,7 @@
             ozpIwc.apiRootUrl="api";
             
             // CONFIG: the base for the OWF7 window.name endpoints
-            ozpIwc.owf7PrefsUrl="/owf/prefs";
+            ozpIwc.owf7PrefsUrl="api/prefs";
 
         </script>
   </head>

--- a/test/integration-tests.html
+++ b/test/integration-tests.html
@@ -19,6 +19,7 @@
     <script type="text/javascript" src="specs/integration/owf7ParticipantListener/modules/eventingSpec.js"></script>
     <script type="text/javascript" src="specs/integration/owf7ParticipantListener/modules/ddSpec.js"></script>
     <script type="text/javascript" src="specs/integration/owf7ParticipantListener/modules/kernelSpec.js"></script>
+    <script type="text/javascript" src="specs/integration/owf7ParticipantListener/modules/intentsSpec.js"></script>
 
     <script type="text/javascript" src="specs/integration/owf7Participant/owf7ParticipantSpec.js"></script>
 </head>

--- a/test/specs/integration/owf7Participant/owf7ParticipantSpec.js
+++ b/test/specs/integration/owf7Participant/owf7ParticipantSpec.js
@@ -1,21 +1,21 @@
 describe("Owf7Participant", function() {
     var listener,participant;
 
-    beforeEach(function(){
+    beforeEach(function(done){
         listener = initTestListener().listener;
         participant = listener.addWidget({
-            url: "http://www.testhost.com/test/path/name.html"
+            url: "http://www.testhost.com/test/path/name.html",
+            onReady: function () {
+                done();
+            }
         });
     });
     afterEach(function(){
         destructTestListener(listener);
+        document.title = "Integration Tests";
     });
 
-    it("Sets the title to [host + pathname] +  '-- OWF Widget' if unable to get the application name from system.api",function(done){
-        participant.setWidgetTitle(function(title){
-            expect(title).toEqual("www.testhost.com/test/path/name.html -- OWF Widget");
-            document.title = "Integration Tests";
-            done();
-        });
+    it("Sets the title to [host + pathname] +  '-- OWF Widget' if the widget does not have a GUID in system.api",function(){
+        expect(document.title).toEqual("www.testhost.com/test/path/name.html -- OWF Widget");
     });
 });

--- a/test/specs/integration/owf7ParticipantListener/modules/intentsSpec.js
+++ b/test/specs/integration/owf7ParticipantListener/modules/intentsSpec.js
@@ -1,0 +1,55 @@
+describe("Eventing", function() {
+    var owf7ParticipantListener,testConfig,functions;
+
+    beforeEach(function(){
+        var config = initTestListener();
+        owf7ParticipantListener = config.listener;
+        functions = config.functions.intents;
+
+        testConfig = {
+            'listener': owf7ParticipantListener,
+            'err': config.err,
+            'rpcMsg': config.rpcMsg,
+            'module': 'intents',
+            'scope': config.rpcMsg,
+            'from': config.rpcMsg.f,
+            'widgetConfig': config.widgetConfig,
+            'fn': undefined, //specify in test
+            'args': [] //specify in test if needed
+        };
+    });
+
+    afterEach(function(){
+        destructTestListener(owf7ParticipantListener);
+    });
+
+    describe("_intents",function(){
+        beforeEach(function(){
+            testConfig.fn = functions._intents;
+            testConfig.handler = 'onIntents';
+        });
+
+        it("can't initialize if the participant does not exist.",function() {
+            expectErr(testConfig);
+        });
+
+        it("calls the corresponding participant's onIntents.",function(){
+            participantCallTest(testConfig);
+        });
+    });
+
+    describe("_intents_receive",function(){
+        beforeEach(function(){
+            testConfig.fn = functions._intents_receive;
+            testConfig.handler = 'onIntentsReceive';
+        });
+
+        it("can't perform an action if the participant does not exist.",function() {
+            expectErr(testConfig);
+        });
+
+        it("calls the corresponding participant's onIntentsReceive.",function(){
+            participantCallTest(testConfig);
+        });
+    });
+});

--- a/test/specs/unit/owf7Participant/owf7ParticipantSpec.js
+++ b/test/specs/unit/owf7Participant/owf7ParticipantSpec.js
@@ -1,0 +1,26 @@
+describe("Owf7Participant", function() {
+    var participant;
+
+    beforeEach(function(){
+
+        participant = new ozpIwc.Owf7Participant({
+            url: "http://www.testhost.com/test/path/name.html",
+            rpcId: "fake",
+            instanceId: "fake",
+            guid: "fake",
+            client: { send: function(){}},
+            listener: {}
+        });
+    });
+    afterEach(function(){
+        document.title = "Unit Tests";
+    });
+    it("Sets the title to the given name",function(){
+        participant.setWidgetTitle("TestTest123");
+        expect(document.title).toEqual("TestTest123");
+    });
+    it("Sets the title to [host + pathname] +  '-- OWF Widget' if no title given",function(){
+        participant.setWidgetTitle();
+        expect(document.title).toEqual("www.testhost.com/test/path/name.html -- OWF Widget");
+    });
+});

--- a/test/specs/unit/owf7ParticipantListener/modules/intentsSpec.js
+++ b/test/specs/unit/owf7ParticipantListener/modules/intentsSpec.js
@@ -1,0 +1,65 @@
+describe("Listener Components Intents", function() {
+    var listener,listenerHandlers,
+        fakeParticipant,fakeParticipantHandlers;
+
+    /**
+     * put this function call on the end of the event loop.
+     * @param fn
+     */
+    function delayForRPC(fn){
+        window.setTimeout(fn,0);
+    }
+
+    beforeEach(function(){
+        listener = new ozpIwc.Owf7ParticipantListener();
+        listenerHandlers = listener.bridge.funcs.intents;
+
+        //Stub a fake participant to spy on bridged handlers
+        fakeParticipant = listener.participants[window.name] = {
+            intents: {
+                onIntents: function () {},
+                onIntentsReceive: function () {}
+            }
+        };
+        fakeParticipantHandlers = fakeParticipant.intents;
+    });
+
+    it("Requires an Owf7ParticipantListener",function(){
+        try{
+            ozpIwc.owf7BridgeModules.intents();
+        } catch (e){
+            expect(e).toEqual("Needs to have an Owf7ParticipantListener");
+        }
+
+        try {
+            ozpIwc.owf7BridgeModules.intents(listener);
+        } catch(e){
+            expect("not to happen").toEqual("true");
+        }
+    });
+
+    it("Is registered to the Listener via its bridge", function(){
+        expect(listenerHandlers._intents).toBeDefined();
+        expect(listenerHandlers._intents_receive).toBeDefined();
+    });
+
+    describe("RPC Registration calls the appropriate participant handler", function(){
+        it("_intents",function(done){
+            spyOn(fakeParticipantHandlers,"onIntents");
+            gadgets.rpc.call("..","_intents",null);
+            delayForRPC(function(){
+                expect(fakeParticipantHandlers.onIntents).toHaveBeenCalled();
+                done();
+            });
+        });
+
+        it("_intents_receive",function(done){
+            spyOn(fakeParticipantHandlers,"onIntentsReceive");
+            gadgets.rpc.call("..","_intents_receive",null);
+            delayForRPC(function(){
+                expect(fakeParticipantHandlers.onIntentsReceive).toHaveBeenCalled();
+                done();
+            });
+        });
+    });
+});

--- a/test/unit-tests.html
+++ b/test/unit-tests.html
@@ -22,6 +22,8 @@
     <script type="text/javascript" src="specs/unit/owf7ParticipantListener/modules/componentsSpec.js"></script>
     <script type="text/javascript" src="specs/unit/owf7ParticipantListener/modules/kernelSpec.js"></script>
 
+    <script type="text/javascript" src="specs/unit/owf7Participant/owf7ParticipantSpec.js"></script>
+
 </head>
 <body>
     <script src="//localhost:35729/livereload.js"></script>


### PR DESCRIPTION
feat(intents): added legacy intent support & app data gathering.
feat(rpc): added postmessage registration on opening parent if same domain (for if parent isn't a legacy widget.)
feat(chore): jshint cleanup.

#26 